### PR TITLE
De bundle

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -44,15 +44,15 @@ func TestBasics(t *testing.T) {
 		// attempt to read non-json with get()
 
 		// getRoot on empty db
-		{"getRoot", `{}`, `{"root":"klra597i7o2u52k222chv2lqeb13v5sd"}`, ""},
+		{"getRoot", `{}`, `{"root":"uosmsi0mbbd1qgf2m0rgfkcrhf32c7om"}`, ""},
 
 		// put
 		{"put", invalidRequest, ``, invalidRequestError},
-		{"getRoot", `{}`, `{"root":"klra597i7o2u52k222chv2lqeb13v5sd"}`, ""}, // getRoot when db didn't change
+		{"getRoot", `{}`, `{"root":"uosmsi0mbbd1qgf2m0rgfkcrhf32c7om"}`, ""}, // getRoot when db didn't change
 		{"put", `{"id": "foo"}`, ``, "value field is required"},
 		{"put", `{"id": "foo", "value": null}`, ``, "value field is required"},
-		{"put", `{"id": "foo", "value": "bar"}`, `{"root":"luskchgmo38ohffb2vh9tmfel0ibbfpa"}`, ""},
-		{"getRoot", `{}`, `{"root":"luskchgmo38ohffb2vh9tmfel0ibbfpa"}`, ""}, // getRoot when db did change
+		{"put", `{"id": "foo", "value": "bar"}`, `{"root":"nti2kt1b288sfhdmqkgnjrog52a7m8ob"}`, ""},
+		{"getRoot", `{}`, `{"root":"nti2kt1b288sfhdmqkgnjrog52a7m8ob"}`, ""}, // getRoot when db did change
 
 		// has
 		{"has", invalidRequest, ``, invalidRequestError},
@@ -64,7 +64,7 @@ func TestBasics(t *testing.T) {
 
 		// putBundle
 		{"putBundle", invalidRequest, ``, invalidRequestError},
-		{"putBundle", fmt.Sprintf(`{"code": %s}`, string(code)), `{"root":"l6ia3192b4iiu552175s89tntlb91q2j"}`, ""},
+		{"putBundle", fmt.Sprintf(`{"code": %s}`, string(code)), `{"root":"nti2kt1b288sfhdmqkgnjrog52a7m8ob"}`, ""},
 
 		// getBundle
 		{"getBundle", invalidRequest, ``, invalidRequestError},
@@ -72,26 +72,26 @@ func TestBasics(t *testing.T) {
 
 		// exec
 		{"exec", invalidRequest, ``, invalidRequestError},
-		{"exec", `{"name": "add", "args": ["bar", 2]}`, `{"result":2,"root":"3pvopt7mij7g29t52u7trl0erln9jbhr"}`, ""},
+		{"exec", `{"name": "add", "args": ["bar", 2]}`, `{"result":2,"root":"01aj0nvumggim5hkm0atuf0s73p9l51e"}`, ""},
 		{"get", `{"id": "bar"}`, `{"has":true,"value":2}`, ""},
 
 		// handleSync
 		{"handleSync", `{"basis":""}`,
-			`{"patch":[{"op":"remove","path":"/"},{"op":"add","path":"/u/bar","value":2},{"op":"add","path":"/u/foo","value":"bar"},{"op":"replace","path":"/s/code","value":"function add(key, d) { var v = db.get(key) || 0; v += d; db.put(key, v); return v; }\n\tfunction log(key, val) { var v = db.get(key) || []; v.push(val); db.put(key, v); }"}],"commitID":"3pvopt7mij7g29t52u7trl0erln9jbhr","nomsChecksum":"2jbp7674jqsv0553qkq0hr68na0tvku1"}`, ""},
+			`{"patch":[{"op":"remove","path":"/"},{"op":"add","path":"/u/bar","value":2},{"op":"add","path":"/u/foo","value":"bar"}],"commitID":"01aj0nvumggim5hkm0atuf0s73p9l51e","nomsChecksum":"2jbp7674jqsv0553qkq0hr68na0tvku1"}`, ""},
 		{"handleSync", `{"basis":"bonk"}`, ``, "Invalid basis hash"},
-		{"handleSync", `{"basis":"l6ia3192b4iiu552175s89tntlb91q2j"}`,
-			`{"patch":[{"op":"add","path":"/u/bar","value":2}],"commitID":"3pvopt7mij7g29t52u7trl0erln9jbhr","nomsChecksum":"2jbp7674jqsv0553qkq0hr68na0tvku1"}`, ""},
+		{"handleSync", `{"basis":"nti2kt1b288sfhdmqkgnjrog52a7m8ob"}`,
+			`{"patch":[{"op":"add","path":"/u/bar","value":2}],"commitID":"01aj0nvumggim5hkm0atuf0s73p9l51e","nomsChecksum":"2jbp7674jqsv0553qkq0hr68na0tvku1"}`, ""},
 
 		// scan
-		{"put", `{"id": "foopa", "value": "doopa"}`, `{"root":"ms3cj5bb0vre25bi6dh11jqlsot8b0mg"}`, ""},
+		{"put", `{"id": "foopa", "value": "doopa"}`, `{"root":"dsvkq4dji7v7kbj70b5tml1go53k516q"}`, ""},
 		{"scan", `{"prefix": "foo"}`, `[{"id":"foo","value":"bar"},{"id":"foopa","value":"doopa"}]`, ""},
 		{"scan", `{"start": {"id": {"value": "foo"}}}`, `[{"id":"foo","value":"bar"},{"id":"foopa","value":"doopa"}]`, ""},
 		{"scan", `{"start": {"id": {"value": "foo", "exclusive": true}}}`, `[{"id":"foopa","value":"doopa"}]`, ""},
 
 		// execBatch
 		{"execBatch", invalidRequest, ``, invalidRequestError},
-		{"execBatch", `[{"name": "add", "args": ["bar", 2]},{"name": ".putBundle", "args": []}]`, `{"error":{"index":1,"detail":"Cannot call system function: .putBundle"},"root":"ms3cj5bb0vre25bi6dh11jqlsot8b0mg"}`, ""},
-		{"execBatch", `[{"name": "add", "args": ["bar", 2]},{"name": "add", "args": ["bar", 2]},{"name": "log", "args": ["log", "bar"]}]`, `{"batch":[{"result":4},{"result":6},{}],"root":"gl7turagjh7cr2o3op4c1q7jo4hbrq4m"}`, ""},
+		{"execBatch", `[{"name": "add", "args": ["bar", 2]},{"name": ".putBundle", "args": []}]`, `{"error":{"index":1,"detail":"Cannot call system function: .putBundle"},"root":"dsvkq4dji7v7kbj70b5tml1go53k516q"}`, ""},
+		{"execBatch", `[{"name": "add", "args": ["bar", 2]},{"name": "add", "args": ["bar", 2]},{"name": "log", "args": ["log", "bar"]}]`, `{"batch":[{"result":4},{"result":6},{}],"root":"qt3a4k7pktg8jhabj2bmfh262ls4gebm"}`, ""},
 		{"get", `{"id": "bar"}`, `{"has":true,"value":6}`, ""},
 		// TODO: other scan operators
 	}

--- a/db/commit_test.go
+++ b/db/commit_test.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/attic-labs/noms/go/chunks"
@@ -18,15 +17,13 @@ func TestMarshal(t *testing.T) {
 	assert := assert.New(t)
 
 	noms := types.NewValueStore((&chunks.TestStorage{}).NewView())
-	emptyBlob := noms.WriteValue(types.NewEmptyBlob(noms))
 	emptyMap := noms.WriteValue(types.NewMap(noms))
 
 	d := datetime.Now()
-	br := noms.WriteValue(types.NewBlob(noms, strings.NewReader("blobdata")))
 	dr := noms.WriteValue(types.NewMap(noms, types.String("foo"), types.String("bar")))
 	args := types.NewList(noms, types.Bool(true), types.String("monkey"))
 	g := makeGenesis(noms, "")
-	tx := makeTx(noms, types.NewRef(g.Original), d, emptyBlob, "func", args, br, dr)
+	tx := makeTx(noms, types.NewRef(g.Original), d, "func", args, dr)
 	noms.WriteValue(g.Original)
 	noms.WriteValue(tx.Original)
 
@@ -40,7 +37,6 @@ func TestMarshal(t *testing.T) {
 				"meta":    types.NewStruct("Genesis", types.StructData{}),
 				"parents": types.NewSet(noms),
 				"value": types.NewStruct("", types.StructData{
-					"code": emptyBlob,
 					"data": emptyMap,
 				}),
 			}),
@@ -53,7 +49,6 @@ func TestMarshal(t *testing.T) {
 				}),
 				"parents": types.NewSet(noms),
 				"value": types.NewStruct("", types.StructData{
-					"code": emptyBlob,
 					"data": emptyMap,
 				}),
 			}),
@@ -64,34 +59,30 @@ func TestMarshal(t *testing.T) {
 				"parents": types.NewSet(noms, types.NewRef(g.Original)),
 				"meta": types.NewStruct("Tx", types.StructData{
 					"date": marshal.MustMarshal(noms, d),
-					"code": emptyBlob,
 					"name": types.String("func"),
 					"args": args,
 				}),
 				"value": types.NewStruct("", types.StructData{
-					"code": br,
 					"data": dr,
 				}),
 			}),
 		},
 		{
-			makeTx(noms, types.NewRef(g.Original), d, br, "func", args, emptyBlob, dr),
+			makeTx(noms, types.NewRef(g.Original), d, "func", args, dr),
 			types.NewStruct("Commit", types.StructData{
 				"parents": types.NewSet(noms, types.NewRef(g.Original)),
 				"meta": types.NewStruct("Tx", types.StructData{
 					"date": marshal.MustMarshal(noms, d),
-					"code": br,
 					"name": types.String("func"),
 					"args": args,
 				}),
 				"value": types.NewStruct("", types.StructData{
-					"code": emptyBlob,
 					"data": dr,
 				}),
 			}),
 		},
 		{
-			makeReorder(noms, types.NewRef(g.Original), d, types.NewRef(tx.Original), br, dr),
+			makeReorder(noms, types.NewRef(g.Original), d, types.NewRef(tx.Original), dr),
 			types.NewStruct("Commit", types.StructData{
 				"parents": types.NewSet(noms, types.NewRef(g.Original), types.NewRef(tx.Original)),
 				"meta": types.NewStruct("Reorder", types.StructData{
@@ -99,7 +90,6 @@ func TestMarshal(t *testing.T) {
 					"subject": types.NewRef(tx.Original),
 				}),
 				"value": types.NewStruct("", types.StructData{
-					"code": br,
 					"data": dr,
 				}),
 			}),

--- a/db/handle_sync.go
+++ b/db/handle_sync.go
@@ -1,9 +1,7 @@
 package db
 
 import (
-	"encoding/json"
 	"errors"
-	"io/ioutil"
 	"log"
 
 	"github.com/attic-labs/noms/go/hash"
@@ -47,22 +45,6 @@ func (db *DB) HandleSync(from hash.Hash) ([]jsonpatch.Operation, error) {
 		for ; i < len(r); i++ {
 			r[i].Path = "/u" + r[i].Path
 		}
-	}
-
-	if !fc.Value.Code.Equals(db.head.Value.Code) {
-		buf, err := ioutil.ReadAll(db.head.Bundle(db.Noms()).Reader())
-		if err != nil {
-			return nil, err
-		}
-		j, err := json.Marshal(string(buf))
-		if err != nil {
-			return nil, err
-		}
-		r = append(r, jsonpatch.Operation{
-			Op:    jsonpatch.OpReplace,
-			Path:  "/s/code",
-			Value: json.RawMessage(j),
-		})
 	}
 
 	return r, nil

--- a/db/handle_sync_test.go
+++ b/db/handle_sync_test.go
@@ -18,9 +18,6 @@ func TestHandleSync(t *testing.T) {
 	fmt.Println(dir)
 
 	bundle := `function set(k, v) { db.put(k, v); }`
-	escapedBundle, err := json.Marshal(bundle)
-	assert.NoError(err)
-
 	var fromID hash.Hash
 	tc := []struct {
 		label         string
@@ -39,13 +36,7 @@ func TestHandleSync(t *testing.T) {
 			func() {
 				db.PutBundle(types.NewBlob(db.Noms(), strings.NewReader(bundle)))
 			},
-			[]jsonpatch.Operation{
-				{
-					Op:    jsonpatch.OpReplace,
-					Path:  "/s/code",
-					Value: escapedBundle,
-				},
-			},
+			[]jsonpatch.Operation{},
 			"",
 		},
 		{

--- a/db/rebase.go
+++ b/db/rebase.go
@@ -52,12 +52,12 @@ func rebase(db *DB, onto types.Ref, date datetime.DateTime, commit Commit, forkP
 	}
 
 	// Otherwise we need to re-execute the transaction against the new basis.
-	var newBundle, newData types.Ref
+	var newData types.Ref
 
 	switch commit.Type() {
 	case CommitTypeTx:
 		// For Tx transactions, just re-run the tx with the new basis.
-		newBundle, newData, _, _, err = db.execImpl(types.NewRef(newBasis.Original), commit.Meta.Tx.Bundle(db.noms), commit.Meta.Tx.Name, commit.Meta.Tx.Args)
+		newData, _, _, err = db.execImpl(types.NewRef(newBasis.Original), commit.Meta.Tx.Name, commit.Meta.Tx.Args)
 		if err != nil {
 			return Commit{}, err
 		}
@@ -70,7 +70,7 @@ func rebase(db *DB, onto types.Ref, date datetime.DateTime, commit Commit, forkP
 		if err != nil {
 			return Commit{}, err
 		}
-		newBundle, newData, _, _, err = db.execImpl(types.NewRef(newBasis.Original), target.Meta.Tx.Bundle(db.noms), target.Meta.Tx.Name, target.Meta.Tx.Args)
+		newData, _, _, err = db.execImpl(types.NewRef(newBasis.Original), target.Meta.Tx.Name, target.Meta.Tx.Args)
 		if err != nil {
 			return Commit{}, err
 		}
@@ -80,7 +80,7 @@ func rebase(db *DB, onto types.Ref, date datetime.DateTime, commit Commit, forkP
 	}
 
 	// Create and return the reorder commit, which will become the basis for the prev frame of the recursive call.
-	newCommit := makeReorder(db.noms, types.NewRef(newBasis.Original), date, types.NewRef(commit.Original), newBundle, newData)
+	newCommit := makeReorder(db.noms, types.NewRef(newBasis.Original), date, types.NewRef(commit.Original), newData)
 	db.noms.WriteValue(newCommit.Original)
 	return newCommit, nil
 }

--- a/db/rebase_test.go
+++ b/db/rebase_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/attic-labs/noms/go/util/datetime"
 	"github.com/stretchr/testify/assert"
 
+	"roci.dev/replicant/util/chk"
 	"roci.dev/replicant/util/noms/diff"
 )
 
@@ -50,8 +51,7 @@ func TestRebase(t *testing.T) {
 	epoch := datetime.DateTime{}
 	bundle := types.NewBlob(noms, strings.NewReader("function log(k, v) { var val = db.get(k) || []; val.push(v); db.put(k, val); }"))
 	err := db.PutBundle(bundle)
-	assert.NoError(err)
-	bundleRef := types.NewRef(bundle)
+	chk.NoError(err)
 
 	tx := func(basis Commit, arg string, ds string) Commit {
 		d := data(ds)
@@ -59,10 +59,8 @@ func TestRebase(t *testing.T) {
 			noms,
 			basis.Ref(),
 			epoch,
-			bundleRef,        // bundle
 			"log",            // function
 			list("foo", arg), // args
-			basis.Value.Code, // result bundle
 			write(d))         // result data
 		write(r.Original)
 		return r
@@ -75,7 +73,6 @@ func TestRebase(t *testing.T) {
 			basis.Ref(),
 			epoch,
 			subject.Ref(),
-			basis.Value.Code,
 			write(d)) // result data
 		write(r.Original)
 		return r

--- a/db/request_sync.go
+++ b/db/request_sync.go
@@ -117,13 +117,6 @@ func (db *DB) RequestSync(remote spec.Spec, progress Progress) error {
 	var ed *types.MapEditor
 	for _, op := range patch {
 		switch {
-		case op.Path == "/s/code":
-			var code string
-			err = json.Unmarshal([]byte(op.Value), &code)
-			if err != nil {
-				return fmt.Errorf("Cannot unmarshal /s/code: %s", err.Error())
-			}
-			head.Value.Code = db.noms.WriteValue(types.NewBlob(db.noms, strings.NewReader(code)))
 		case strings.HasPrefix(op.Path, "/u"):
 			if ed == nil {
 				ed = db.head.Data(db.noms).Edit()

--- a/db/validate.go
+++ b/db/validate.go
@@ -7,22 +7,22 @@ import "fmt"
 func validate(db *DB, commit Commit) (replayed Commit, err error) {
 	switch commit.Type() {
 	case CommitTypeTx:
-		newBundle, newData, _, _, err := db.execImpl(commit.BasisRef(), commit.Meta.Tx.Bundle(db.noms), commit.Meta.Tx.Name, commit.Meta.Tx.Args)
+		newData, _, _, err := db.execImpl(commit.BasisRef(), commit.Meta.Tx.Name, commit.Meta.Tx.Args)
 		if err != nil {
 			return Commit{}, err
 		}
-		return makeTx(db.noms, commit.BasisRef(), commit.Meta.Tx.Date, commit.Meta.Tx.Code, commit.Meta.Tx.Name, commit.Meta.Tx.Args, newBundle, newData), nil
+		return makeTx(db.noms, commit.BasisRef(), commit.Meta.Tx.Date, commit.Meta.Tx.Name, commit.Meta.Tx.Args, newData), nil
 
 	case CommitTypeReorder:
 		target, err := commit.InitalCommit(db.noms)
 		if err != nil {
 			return Commit{}, err
 		}
-		newBundle, newData, _, _, err := db.execImpl(commit.BasisRef(), target.Meta.Tx.Bundle(db.noms), target.Meta.Tx.Name, target.Meta.Tx.Args)
+		newData, _, _, err := db.execImpl(commit.BasisRef(), target.Meta.Tx.Name, target.Meta.Tx.Args)
 		if err != nil {
 			return Commit{}, err
 		}
-		return makeReorder(db.noms, commit.BasisRef(), commit.Meta.Reorder.Date, commit.Target(), newBundle, newData), nil
+		return makeReorder(db.noms, commit.BasisRef(), commit.Meta.Reorder.Date, commit.Target(), newData), nil
 	}
 
 	// We should never get asked to validate other commit types:

--- a/db/validate_test.go
+++ b/db/validate_test.go
@@ -17,6 +17,7 @@ func TestValidate(t *testing.T) {
 
 	db, dir := LoadTempDB(assert)
 	fmt.Println(dir)
+	db.PutBundle(types.NewBlob(db.Noms(), strings.NewReader("function log(k, v) { var val = db.get(k) || []; val.push(v); db.put(k, val); }")))
 	noms := db.noms
 
 	list := func(items ...string) types.List {
@@ -29,8 +30,6 @@ func TestValidate(t *testing.T) {
 
 	epoch := datetime.DateTime{}
 	g := makeGenesis(noms, "")
-	eb := types.NewEmptyBlob(noms)
-	b1 := types.NewBlob(noms, strings.NewReader("function log(k, v) { var val = db.get(k) || []; val.push(v); db.put(k, val); }"))
 	d1 := types.NewMap(noms,
 		types.String("foo"),
 		list("bar"))
@@ -42,10 +41,8 @@ func TestValidate(t *testing.T) {
 		noms,
 		noms.WriteValue(g.Original),
 		epoch,
-		noms.WriteValue(b1),
 		"log",
 		list("foo", "bar"),
-		noms.WriteValue(eb),
 		noms.WriteValue(d1))
 	noms.WriteValue(tx1.Original)
 
@@ -53,10 +50,8 @@ func TestValidate(t *testing.T) {
 		noms,
 		noms.WriteValue(g.Original),
 		epoch,
-		noms.WriteValue(b1),
 		"log",
 		list("foo", "bar"),
-		noms.WriteValue(eb),
 		noms.WriteValue(d2)) // incorrect, should be d1
 	noms.WriteValue(tx1b.Original)
 
@@ -64,10 +59,8 @@ func TestValidate(t *testing.T) {
 		noms,
 		noms.WriteValue(tx1.Original),
 		epoch,
-		noms.WriteValue(b1),
 		"log",
 		list("foo", "baz"),
-		noms.WriteValue(eb),
 		noms.WriteValue(d2))
 	noms.WriteValue(tx2.Original)
 
@@ -75,10 +68,8 @@ func TestValidate(t *testing.T) {
 		noms,
 		noms.WriteValue(tx1b.Original), // basis is incorrect
 		epoch,
-		noms.WriteValue(b1),
 		"log",
 		list("foo", "baz"),
-		noms.WriteValue(eb),
 		noms.WriteValue(
 			d2.Edit().Set(
 				types.String("foo"),
@@ -89,10 +80,8 @@ func TestValidate(t *testing.T) {
 		noms,
 		noms.WriteValue(g.Original),
 		epoch,
-		noms.WriteValue(b1),
 		"log",
 		list("foo", "quux"),
-		noms.WriteValue(eb),
 		noms.WriteValue(
 			types.NewMap(noms, types.String("foo"), list("quux"))))
 	noms.WriteValue(tx3.Original)
@@ -101,7 +90,6 @@ func TestValidate(t *testing.T) {
 		noms.WriteValue(tx1.Original),
 		epoch,
 		noms.WriteValue(tx3.Original),
-		noms.WriteValue(eb),
 		noms.WriteValue(
 			types.NewMap(noms, types.String("foo"), list("bar", "quux"))))
 	noms.WriteValue(ro1.Original)
@@ -110,7 +98,6 @@ func TestValidate(t *testing.T) {
 		noms.WriteValue(tx1.Original),
 		epoch,
 		noms.WriteValue(tx3.Original),
-		noms.WriteValue(eb),
 		noms.WriteValue(
 			types.NewMap(noms, types.String("foo"), list("bar", "monkey")))) // incorrect
 	noms.WriteValue(ro1b.Original)
@@ -119,7 +106,6 @@ func TestValidate(t *testing.T) {
 		noms.WriteValue(tx1b.Original), // incorrect basis
 		epoch,
 		noms.WriteValue(tx3.Original),
-		noms.WriteValue(eb),
 		noms.WriteValue(
 			types.NewMap(noms, types.String("foo"), list("bar", "baz", "quux"))))
 	noms.WriteValue(ro1c.Original)

--- a/exec/otto.go
+++ b/exec/otto.go
@@ -79,6 +79,10 @@ func Run(db Database, source io.Reader, fn string, args types.List) (types.Value
 		return nil, errDetail(err)
 	}
 
+	if fn == "" {
+		return nil, nil
+	}
+
 	vm.Set("send", func(call o.FunctionCall) o.Value {
 		args := call.ArgumentList
 		cmdID, err := args[0].ToInteger()

--- a/serve/server.go
+++ b/serve/server.go
@@ -27,7 +27,7 @@ import (
 )
 
 var (
-	commands = []string{"getRoot", "has", "get", "scan", "put", "del", "getBundle", "putBundle", "exec", "execBatch", "handleSync"}
+	commands = []string{"handleSync"}
 )
 
 // server is a single Replicant instance. The Replicant service runs many such instances.

--- a/serve/service_test.go
+++ b/serve/service_test.go
@@ -95,7 +95,7 @@ func TestCheckAccess(t *testing.T) {
 		svc := NewService(td, accounts)
 		res := httptest.NewRecorder()
 
-		req := httptest.NewRequest("POST", fmt.Sprintf("/%s/%s/put", t.accountID, t.dbName), strings.NewReader(`{"id":"foo","value":"bar"}`))
+		req := httptest.NewRequest("POST", fmt.Sprintf("/%s/%s/handleSync", t.accountID, t.dbName), strings.NewReader(`{"basis": "00000000000000000000000000000000"}`))
 		req.Header.Add("Authorization", t.token)
 		svc.ServeHTTP(res, req)
 
@@ -116,6 +116,7 @@ func TestCheckAccess(t *testing.T) {
 }
 
 func TestConcurrentAccessUsingMultipleServices(t *testing.T) {
+	// TO
 	assert := assert.New(t)
 	td, _ := ioutil.TempDir("", "")
 
@@ -136,9 +137,9 @@ func TestConcurrentAccessUsingMultipleServices(t *testing.T) {
 		httptest.NewRecorder(),
 	}
 
-	svc1.ServeHTTP(res[0], httptest.NewRequest("POST", "/sandbox/foo/put", strings.NewReader(`{"id":"foo","value":"bar"}`)))
-	svc2.ServeHTTP(res[1], httptest.NewRequest("POST", "/sandbox/foo/put", strings.NewReader(`{"id":"foo","value":"bar"}`)))
-	svc1.ServeHTTP(res[2], httptest.NewRequest("POST", "/sandbox/foo/put", strings.NewReader(`{"id":"foo","value":"bar"}`)))
+	svc1.ServeHTTP(res[0], httptest.NewRequest("POST", "/sandbox/foo/handleSync", strings.NewReader(`{"basis": "00000000000000000000000000000000"}`)))
+	svc2.ServeHTTP(res[1], httptest.NewRequest("POST", "/sandbox/foo/handleSync", strings.NewReader(`{"basis": "00000000000000000000000000000000"}`)))
+	svc1.ServeHTTP(res[2], httptest.NewRequest("POST", "/sandbox/foo/handleSync", strings.NewReader(`{"basis": "00000000000000000000000000000000"}`)))
 
 	for i, r := range res {
 		assert.Equal(http.StatusOK, r.Code, fmt.Sprintf("response %d: %s", i, string(r.Body.Bytes())))


### PR DESCRIPTION
This is WIP that attempts to remove the feature of Replicant where the bundle is persistently stored (and synced).

Instead clients must provide the bundle at runtime each time they instantiate the library.

Open question on how this works in the CLI and the HTTP bindings.